### PR TITLE
Removes installation of CURL to allow CircleCI tests to pass.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - sudo apt-get install -y curl
+#    - sudo apt-get install -y curl
     - curl -sL https://deb.nodesource.com/setup | sudo bash -
     - sudo apt-get install -y build-essential git nodejs
     - npm -g install npm@2.1.5

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
 
 dependencies:
   override:
-#    - sudo apt-get install -y curl
     - curl -sL https://deb.nodesource.com/setup | sudo bash -
     - sudo apt-get install -y build-essential git nodejs
     - npm -g install npm@2.1.5


### PR DESCRIPTION
# Why?

CI tests were failing.
# What changed?

CircleCI config seems to be to blame. Removed a command in `circle.yml` that was failing (installation of curl; curl is installed by default)
